### PR TITLE
Fix password fields not cleared in register page

### DIFF
--- a/register.php
+++ b/register.php
@@ -185,12 +185,12 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
 					</div>    
 					<div class="form-group">
 						<label>Kata Laluan</label>
-						<input type="password" name="password" class="form-control <?php echo (!empty($password_err)) ? 'is-invalid' : ''; ?>" value="<?php echo $password; ?>">
+                                                <input type="password" name="password" class="form-control <?php echo (!empty($password_err)) ? 'is-invalid' : ''; ?>">
 						<span class="invalid-feedback"><?php echo $password_err; ?></span>
 					</div>
 					<div class="form-group">
 						<label>Sahkan Kata Laluan</label>
-						<input type="password" name="confirm_password" class="form-control <?php echo (!empty($confirm_password_err)) ? 'is-invalid' : ''; ?>" value="<?php echo $confirm_password; ?>">
+                                                <input type="password" name="confirm_password" class="form-control <?php echo (!empty($confirm_password_err)) ? 'is-invalid' : ''; ?>">
 						<span class="invalid-feedback"><?php echo $confirm_password_err; ?></span>
 					</div>
 					<div class="form-group">
@@ -239,12 +239,12 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
             </div>    
             <div class="form-group">
                 <label>Password</label>
-                <input type="password" name="password" class="form-control <?php echo (!empty($password_err)) ? 'is-invalid' : ''; ?>" value="<?php echo $password; ?>">
+                <input type="password" name="password" class="form-control <?php echo (!empty($password_err)) ? 'is-invalid' : ''; ?>">
                 <span class="invalid-feedback"><?php echo $password_err; ?></span>
             </div>
             <div class="form-group">
                 <label>Confirm Password</label>
-                <input type="password" name="confirm_password" class="form-control <?php echo (!empty($confirm_password_err)) ? 'is-invalid' : ''; ?>" value="<?php echo $confirm_password; ?>">
+                <input type="password" name="confirm_password" class="form-control <?php echo (!empty($confirm_password_err)) ? 'is-invalid' : ''; ?>">
                 <span class="invalid-feedback"><?php echo $confirm_password_err; ?></span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
## Summary
- avoid repopulating password fields after failed registration

## Testing
- `grep -n "password" -n register.php | head`

------
https://chatgpt.com/codex/tasks/task_b_683d0fbed684832fbecdac68c794cf7a